### PR TITLE
Remove context random_generator

### DIFF
--- a/main/main_desktop.odin
+++ b/main/main_desktop.odin
@@ -84,7 +84,6 @@ main :: proc() {
 		}
 	}
 
-	context.random_generator = crypto.random_generator()
 	context.logger = log.create_console_logger()
 	context.logger.lowest_level = LOG_LEVEL
 	defer log.destroy_console_logger(context.logger)


### PR DESCRIPTION
`rand_bytes` doesn't need the random generator set to work correctly: https://github.com/odin-lang/Odin/blob/3a13c598e2efb46f12121bb532f8f3616d2cf482/core/crypto/crypto.odin#L56